### PR TITLE
Set Geocoder lookup in tests so cassettes will work

### DIFF
--- a/test/system/workarea/storefront/shipping_estimation_system_test.rb
+++ b/test/system/workarea/storefront/shipping_estimation_system_test.rb
@@ -3,7 +3,11 @@ require 'test_helper'
 module Workarea
   module Storefront
     class ShippingEstimationSystemTest < Workarea::SystemTest
-      setup :product, :tax_category, :shipping_service
+      setup :configure_geocoder, :product, :tax_category, :shipping_service
+
+      def configure_geocoder
+        Geocoder.configure(lookup: :google)
+      end
 
       def product
         @product = create_product(


### PR DESCRIPTION
This will avoid changes in default Geocoder changing test behavior.